### PR TITLE
fixed a bug when exporting

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
 		<!-- HTML Meta Tags -->
 		<title>
-			Nassi-Shneiderman diagram builder
+			Nassi-Shneiderman Diagram Builder
 		</title>
 		<meta
 			name="description"

--- a/src/App/theme.ts
+++ b/src/App/theme.ts
@@ -5,11 +5,12 @@ import {
 
 export const themeDark = createTheme({
 	palette: {
+		mode: "dark",
 		primary: {
 			main: "#e1cdfe",
 		},
 		text: {
-			primary: alpha("#f00", 0.9),
+			primary: alpha("#fff", 0.9),
 		},
 		background: {
 			paper: "#2B2828",

--- a/src/components/DiagramPreview.tsx
+++ b/src/components/DiagramPreview.tsx
@@ -10,6 +10,7 @@ import { Diagram } from "./Diagram";
 
 const StyledBox = styled(Box)(({ theme }) => ({
 	maxWidth: "640px",
+	backgroundColor: theme.palette.common.white,
 	borderColor: theme.palette.text.primary,
 }));
 


### PR DESCRIPTION
Resolved a bug for which the exported diagram is a blacked out resulting in a black rectangle.

Bug resolved via setting the background color of the preview element to an explicit color.